### PR TITLE
Replace outdated XRB prefix with newer NANO prefix

### DIFF
--- a/src/coins.c
+++ b/src/coins.c
@@ -14,8 +14,8 @@ REGISTER_COINS(
         #endif
         .bip32Prefix = { HARDENED(44), HARDENED(165) },
         .addressPrimaryPrefix = "nano_",
-        .addressSecondaryPrefix = "xrb_",
-        .addressDefaultPrefix = LIBN_SECONDARY_PREFIX,
+        .addressSecondaryPrefix = "nano_",
+        .addressDefaultPrefix = LIBN_PRIMARY_PREFIX,
         .defaultUnit = "NANO",
         .defaultUnitScale = 30, // 1 Mnano = 10^30 raw
         #if defined(TARGET_BLUE)

--- a/src/coins.c
+++ b/src/coins.c
@@ -14,8 +14,8 @@ REGISTER_COINS(
         #endif
         .bip32Prefix = { HARDENED(44), HARDENED(165) },
         .addressPrimaryPrefix = "nano_",
-        .addressSecondaryPrefix = "nano_",
-        .addressDefaultPrefix = LIBN_PRIMARY_PREFIX,
+        .addressSecondaryPrefix = "xrb_",
+        .addressDefaultPrefix = "nano_",
         .defaultUnit = "NANO",
         .defaultUnitScale = 30, // 1 Mnano = 10^30 raw
         #if defined(TARGET_BLUE)

--- a/src/coins.c
+++ b/src/coins.c
@@ -15,7 +15,7 @@ REGISTER_COINS(
         .bip32Prefix = { HARDENED(44), HARDENED(165) },
         .addressPrimaryPrefix = "nano_",
         .addressSecondaryPrefix = "xrb_",
-        .addressDefaultPrefix = "nano_",
+        .addressDefaultPrefix = LIBN_PRIMARY_PREFIX,
         .defaultUnit = "NANO",
         .defaultUnitScale = 30, // 1 Mnano = 10^30 raw
         #if defined(TARGET_BLUE)


### PR DESCRIPTION
No wallets use the XRB prefix. It's safe to change to NANO_