### PR TITLE
Remove 'and send' from Ledger X accept-notification

### DIFF
--- a/src/libn_bagl_nanox.c
+++ b/src/libn_bagl_nanox.c
@@ -365,6 +365,7 @@ UX_STEP_CB(
     {
         &C_icon_validate_14,
         "Accept",
+        "and sign",
     });
 UX_STEP_CB(
     ux_confirm_sign_block_flow_8_step,

--- a/src/libn_bagl_nanox.c
+++ b/src/libn_bagl_nanox.c
@@ -365,7 +365,6 @@ UX_STEP_CB(
     {
         &C_icon_validate_14,
         "Accept",
-        "and send",
     });
 UX_STEP_CB(
     ux_confirm_sign_block_flow_8_step,


### PR DESCRIPTION
Fixes #6 

To avoid confusion when creating a change- or receive-block (which is not a send). The term was most likely never meant to refer to the block type but anyway, I think this is better.